### PR TITLE
Added method to return current locale on antl

### DIFF
--- a/src/Antl/index.js
+++ b/src/Antl/index.js
@@ -68,6 +68,17 @@ class Antl {
   }
 
   /**
+   * Returns the current locale
+   *
+   * @method currentLocale
+   *
+   * @return {String} locale
+   */
+  currentLocale () {
+    return this._locale
+  }
+
+  /**
    * @see('Formatter.formatNumber')
    */
   formatNumber (...args) {

--- a/test/antl.spec.js
+++ b/test/antl.spec.js
@@ -88,6 +88,11 @@ test.group('Antl', () => {
     assert.equal(antl.get('validations.email.required'), 'Email is required')
   })
 
+  test('return current locale', (assert) => {
+    const antl = new Antl('en-us')
+    assert.equal(antl.currentLocale(), 'en-us')
+  })
+
   test('return the default value when nothing has been found', (assert) => {
     const antl = new Antl('en-us', {
       'en-us': {


### PR DESCRIPTION
Added the `currentLocale()` method on the Antl class

Closes #35 