### PR TITLE
Make sure key in antl.formatMessage() is a string before splitting, return default value if not

### DIFF
--- a/src/Antl/index.js
+++ b/src/Antl/index.js
@@ -124,6 +124,13 @@ class Antl {
    * @return {Mixed}
    */
   get (key, defaultValue = null) {
+    /**
+     * Make sure key is a string before attempting to split it
+     */
+    if (typeof (key) !== 'string') {
+      return defaultValue
+    }
+
     const [group, ...parts] = key.split('.')
     const messageKey = parts.join('.')
 

--- a/test/antl.spec.js
+++ b/test/antl.spec.js
@@ -125,19 +125,34 @@ test.group('Antl', () => {
     assert.isNull(antl.get('validations.age.required'))
   })
 
-  test.failing('return the default value when key is null', (assert) => {
+  test('return the default value when key is null', (assert) => {
     const antl = new Antl('en-us')
     assert.equal(antl.get(null, 'translation missing'), 'translation missing')
   })
 
-  test.failing('return the default value when key is undefined', (assert) => {
+  test('return null when key is null and no default value is defined', (assert) => {
+    const antl = new Antl('en-us')
+    assert.isNull(antl.get(null))
+  })
+
+  test('return the default value when key is undefined', (assert) => {
     const antl = new Antl('en-us')
     assert.equal(antl.get(undefined, 'translation missing'), 'translation missing')
   })
 
-  test.failing('return the default value when key is not a string', (assert) => {
+  test('return null when key is undefined and no default value is defined', (assert) => {
+    const antl = new Antl('en-us')
+    assert.isNull(antl.get(undefined))
+  })
+
+  test('return the default value when key is not a string', (assert) => {
     const antl = new Antl('en-us')
     assert.equal(antl.get([], 'translation missing'), 'translation missing')
+  })
+
+  test('return null when key is not a string and no default value is defined', (assert) => {
+    const antl = new Antl('en-us')
+    assert.isNull(antl.get({}))
   })
 
   test('return a list of strings', (assert) => {

--- a/test/antl.spec.js
+++ b/test/antl.spec.js
@@ -125,6 +125,21 @@ test.group('Antl', () => {
     assert.isNull(antl.get('validations.age.required'))
   })
 
+  test.failing('return the default value when key is null', (assert) => {
+    const antl = new Antl('en-us')
+    assert.equal(antl.get(null, 'translation missing'), 'translation missing')
+  })
+
+  test.failing('return the default value when key is undefined', (assert) => {
+    const antl = new Antl('en-us')
+    assert.equal(antl.get(undefined, 'translation missing'), 'translation missing')
+  })
+
+  test.failing('return the default value when key is not a string', (assert) => {
+    const antl = new Antl('en-us')
+    assert.equal(antl.get([], 'translation missing'), 'translation missing')
+  })
+
   test('return a list of strings', (assert) => {
     const messages = {
       'en-us': {


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Check to make sure that the key being passed to antl.formatMessage() is a string before using .split() on it in order to prevent errors/exceptions trying to use a string function on a non-string. 

If the key is not a string, return the default value. This seems appropriate given the fact that if the key is not found, the default is returned.

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-antl/blob/develop/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

This is a relatively small change to fix a bug and avoid having to try/catch around instances of antl.formatMessage() in cases where the key may be sourced from a variable.
