### PR TITLE
fix(formatter): zero triggering fallback return

### DIFF
--- a/src/Formatter/index.js
+++ b/src/Formatter/index.js
@@ -48,7 +48,7 @@ class Formatter {
    * ```
    */
   formatNumber (value, options, fallback) {
-    if (!value) {
+    if (!value && value !== 0) {
       return fallback || null
     }
     const formattingOptions = Object.assign({}, options)


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

This pull request fixes issue #38 

When passing zero in formatNumber, it was considered falsey and triggered the fallback return statement resulting in a null return. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-antl/blob/develop/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
