### PR TITLE
Improve error when translation is missing for a given key

### DIFF
--- a/src/Antl/index.js
+++ b/src/Antl/index.js
@@ -108,9 +108,19 @@ class Antl {
 
   /**
    * @see('Formatter.formatMessage')
+   *
+   * @throws {InvalidArgumentException} If translation is not found
    */
   formatMessage (key, ...args) {
-    return this._formatter.formatMessage(this.get(key), ...args)
+    const rawMessage = this.get(key)
+
+    if (!rawMessage) {
+      throw GE
+        .InvalidArgumentException
+        .invalidParameter(`Missing ${this._locale} translation for key '${key}'`)
+    }
+
+    return this._formatter.formatMessage(rawMessage, ...args)
   }
 
   /**

--- a/test/antl.spec.js
+++ b/test/antl.spec.js
@@ -57,6 +57,25 @@ test.group('Antl', () => {
     assert.equal(antl.formatMessage('header.hello', { name: 'Peter' }), 'Hello Peter')
   })
 
+  test('format message throws exception when translation is missing', (assert) => {
+    const antl = new Antl('en-us', {
+      'en-us': {
+        'validations': {
+          'name.required': 'Name is required'
+        }
+      },
+      '*': {
+        'validations': {
+          'email.required': 'Email is required'
+        }
+      }
+    })
+
+    const fn = () => antl.formatMessage('validations.age.required')
+
+    assert.throw(fn, 'E_INVALID_PARAMETER: Missing en-us translation for key \'validations.age.required\'')
+  })
+
   test('get message for a key', (assert) => {
     const antl = new Antl('en-us', {
       'en-us': {

--- a/test/antl.spec.js
+++ b/test/antl.spec.js
@@ -45,6 +45,18 @@ test.group('Antl', () => {
     assert.equal(antl.formatRelative(today.getTime()), 'now')
   })
 
+  test('format message for a given locale', (assert) => {
+    const antl = new Antl('en-us', {
+      'en-us': {
+        'header': {
+          'hello': 'Hello {name}'
+        }
+      }
+    })
+
+    assert.equal(antl.formatMessage('header.hello', { name: 'Peter' }), 'Hello Peter')
+  })
+
   test('get message for a key', (assert) => {
     const antl = new Antl('en-us', {
       'en-us': {


### PR DESCRIPTION
## Proposed changes

Today, if I try to fetch a message passing the wrong key I get an error from the `intl-messageformat` lib:

```
> const Antl = use('Antl')
> Antl.formatMessage('messages.greeting')
TypeError: A message must be provided as a String or AST.
    at new MessageFormat (/Users/viny/Projects/fleury-checkup-executivo/node_modules/intl-messageformat/lib/core.js:21:15)
    at /Users/viny/Projects/fleury-checkup-executivo/node_modules/intl-format-cache/lib/memoizer.js:24:22
    at Formatter.formatMessage (/Users/viny/Projects/fleury-checkup-executivo/node_modules/@adonisjs/antl/src/Formatter/index.js:177:12)
    at Antl.formatMessage (/Users/viny/Projects/fleury-checkup-executivo/node_modules/@adonisjs/antl/src/Antl/index.js:113:28)
    at repl:1:6
    at Script.runInContext (vm.js:107:20)
    at REPLServer.defaultEval (repl.js:331:29)
    at bound (domain.js:396:14)
    at REPLServer.runBound (domain.js:409:12)

```

I've changed the code so we can have a more descriptive error containing the current locale and key:

```
InvalidArgumentException: E_INVALID_PARAMETER: Missing pt translation for key 'messages.greeting'
```

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-antl/blob/develop/CONTRIBUTING.md) doc
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have added necessary documentation (if appropriate)

## Further comments

Maybe we should create some integration tests. This is a case that the suite was not covering...