### PR TITLE
Allow nested dot syntax

### DIFF
--- a/src/Antl/index.js
+++ b/src/Antl/index.js
@@ -135,7 +135,6 @@ class Antl {
    */
   get (key, defaultValue = null) {
     const [group, ...parts] = key.split('.')
-    const messageKey = parts.join('.')
 
     /**
      * Look for the message inside the locale message
@@ -143,7 +142,7 @@ class Antl {
      *
      * @type {Array}
      */
-    const localeNode = [this._locale, group, messageKey]
+    const localeNode = [this._locale, group, ...parts]
 
     /**
      * The fallback node is used when value has not been found
@@ -152,7 +151,7 @@ class Antl {
      * @type {Array}
      */
     const fallbackKey = this._messages['*'] ? '*' : 'fallback'
-    const fallbackNode = [fallbackKey, group, messageKey]
+    const fallbackNode = [fallbackKey, group, ...parts]
 
     debug('getting message for %s key from store', localeNode.join('.'))
     debug('using fallback key as %s', fallbackNode.join('.'))


### PR DESCRIPTION
## Proposed changes

This change fixed a bug and allow to have nested dot syntax like this:
```js
a: {
  b: {
    c: "d",
    e: "f"
  }
}
```
because it's actually not working after 1 nested element and we have to do:
```js
a: {
  "b.c": "d",
  "b.e": "f"
}
```

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/adonis-antl/blob/develop/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)