### PR TITLE
Updated locale method to use default locale when none is provided

### DIFF
--- a/src/i18n_manager.ts
+++ b/src/i18n_manager.ts
@@ -249,8 +249,8 @@ export class I18nManager {
   /**
    * Returns an instance of I18n for a given locale
    */
-  locale(locale: string) {
-    return new I18n(locale, this.#emitter, this)
+  locale(locale?: string) {
+    return new I18n(locale || this.defaultLocale, this.#emitter, this)
   }
 
   /**


### PR DESCRIPTION
### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [X] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This change modifies the locale method to provide a default locale if none is specified. Previously, if the locale parameter was omitted, it would result in an undefined value being passed to the I18n instance. By using locale || this.defaultLocale, we ensure that the default locale is used, improving usability.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
