### PR TITLE
fix: add support for vinejs messages provider by getting otherField

### DIFF
--- a/src/vine_i18n_messages_provider.ts
+++ b/src/vine_i18n_messages_provider.ts
@@ -51,6 +51,17 @@ export class I18nMessagesProvider implements MessagesProviderContact {
     if (translatedFieldName) {
       fieldName = this.#i18n.formatRawMessage(translatedFieldName.message)
     }
+    /**
+     * Checking if vine's meta comes with otherField
+     */
+    if (meta?.otherField) {
+      const translatedOtherFieldName = this.#i18n.resolveIdentifier(
+        `${this.#fieldsPrefix}.${meta.otherField}`
+      )
+      if (translatedOtherFieldName) {
+        meta.otherField = this.#i18n.formatRawMessage(translatedOtherFieldName.message)
+      }
+    }
 
     /**
      * 1st priority is given to the field messages
@@ -63,13 +74,6 @@ export class I18nMessagesProvider implements MessagesProviderContact {
         field: fieldName,
         ...meta,
       })
-    }
-    /**
-     * Checking if vine's meta comes with otherField
-     */
-    if (meta?.otherField) {
-      const translatedOtherFieldName = this.#i18n.resolveIdentifier(`${this.#fieldsPrefix}.${meta.otherField}`);
-      meta.otherField = this.#i18n.formatRawMessage(translatedOtherFieldName.message);
     }
     /**
      * 2nd priority is for rule messages

--- a/src/vine_i18n_messages_provider.ts
+++ b/src/vine_i18n_messages_provider.ts
@@ -64,7 +64,13 @@ export class I18nMessagesProvider implements MessagesProviderContact {
         ...meta,
       })
     }
-
+    /**
+     * Checking if vine's meta comes with otherField
+     */
+    if (meta?.otherField) {
+      const translatedOtherFieldName = this.#i18n.resolveIdentifier(`${this.#fieldsPrefix}.${meta.otherField}`);
+      meta.otherField = this.#i18n.formatRawMessage(translatedOtherFieldName.message);
+    }
     /**
      * 2nd priority is for rule messages
      */


### PR DESCRIPTION
### 🔗 Linked issue

Vinejs messages provider not getting otherField #140

### ❓ Type of change

- [x ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Checking if vine's meta comes with `otherField`, if so it gets its translation
An error was occurring when defining validator's rule like this `"confirmed": "The {{ field }} field and {{ otherField }} field must be the same"`
Resolves #140

### 📝 Checklist

- [x ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
