### PR TITLE
feat: add command to publish localization templates

### DIFF
--- a/commands/publish.ts
+++ b/commands/publish.ts
@@ -1,0 +1,64 @@
+/*
+ * @adonisjs/core
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { writeFile, readFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { BaseCommand } from '@adonisjs/core/ace'
+
+/**
+ * Publish localization templates
+ */
+export default class MakeCommand extends BaseCommand {
+  static commandName = 'lang:publish'
+  static description = 'Eject localization templates to resources/lang/en directory'
+
+  async run() {
+    let messages: any = {}
+    try {
+      const vine = await import('@vinejs/vine/defaults')
+      messages = vine.messages
+    } catch {
+      this.logger.error('Vine is not installed. No localization templates to publish.')
+      return
+    }
+
+    const destination = this.app.languageFilesPath('en', 'validator.json')
+
+    let validatorMessages = {
+      shared: {
+        messages: {},
+      },
+    }
+
+    if (existsSync(destination)) {
+      try {
+        validatorMessages = JSON.parse(await readFile(destination, 'utf-8'))
+      } catch {
+        this.logger.warning(
+          'Failed to parse existing validator.json. Overwriting with default contents.'
+        )
+      }
+    }
+
+    validatorMessages = {
+      ...validatorMessages,
+      shared: {
+        ...validatorMessages.shared,
+        messages: {
+          ...messages,
+          ...validatorMessages.shared?.messages,
+        },
+      },
+    }
+
+    await writeFile(destination, JSON.stringify(validatorMessages, null, 2))
+
+    this.logger.success('Localization template published to resources/lang/en/validator.json')
+  }
+}


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

https://github.com/orgs/adonisjs/discussions/5035

Inspired by Laravel's `php artisan lang:publish` command. Eject translation template of built-in validation messages to `/resources/lang/en/validator.json`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
