### PR TITLE
feat(serveFiles): serve translation files over http

### DIFF
--- a/providers/i18n_provider.ts
+++ b/providers/i18n_provider.ts
@@ -97,7 +97,7 @@ export default class I18nProvider {
       }
 
       router
-        .get(loader.serveFiles.routePattern, createFileServer(loader.serveFiles.location))
+        .get(loader.serveFiles.routePattern, createFileServer(loader))
         .as(`i18n.fs.${index}.serve`)
     })
 

--- a/providers/i18n_provider.ts
+++ b/providers/i18n_provider.ts
@@ -14,6 +14,7 @@ import type { ApplicationService } from '@adonisjs/core/types'
 import { createFileServer } from '../src/file_server.ts'
 import { I18nManager } from '../src/i18n_manager.ts'
 import type { MissingTranslationEventPayload } from '../src/types.ts'
+import { FsLoader } from '../src/loaders/fs.ts'
 
 declare module '@adonisjs/core/types' {
   export interface EventsList {
@@ -91,7 +92,7 @@ export default class I18nProvider {
     i18nManager.config.loaders.forEach((loaderFactory, index) => {
       const loader = loaderFactory(i18nManager.config)
 
-      if (!loader.serveFiles) {
+      if (!(loader instanceof FsLoader) || !loader.serveFiles) {
         return
       }
 

--- a/providers/i18n_provider.ts
+++ b/providers/i18n_provider.ts
@@ -11,6 +11,7 @@ import { configProvider } from '@adonisjs/core'
 import { RuntimeException } from '@adonisjs/core/exceptions'
 import type { ApplicationService } from '@adonisjs/core/types'
 
+import { createFileServer } from '../src/file_server.ts'
 import { I18nManager } from '../src/i18n_manager.ts'
 import type { MissingTranslationEventPayload } from '../src/types.ts'
 
@@ -82,6 +83,22 @@ export default class I18nProvider {
      */
     const i18nManager = await this.app.container.make('i18n')
     await i18nManager.loadTranslations()
+
+    /**
+     * Serve files over HTTP when using FS loader with "serveFiles" option enabled.
+     */
+    const router = await this.app.container.make('router')
+    i18nManager.config.loaders.forEach((loaderFactory, index) => {
+      const loader = loaderFactory(i18nManager.config)
+
+      if (!loader.serveFiles) {
+        return
+      }
+
+      router
+        .get(loader.serveFiles.routePattern, createFileServer(loader.serveFiles.location))
+        .as(`i18n.fs.${index}.serve`)
+    })
 
     await this.registerEdgePlugin(i18nManager)
     await this.registerReplBindings()

--- a/src/file_server.ts
+++ b/src/file_server.ts
@@ -1,0 +1,71 @@
+/*
+ * @adonisjs/i18n
+ *
+ * (c) AdonisJS
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { extname, resolve } from 'node:path'
+import { stat } from 'node:fs/promises'
+import { createReadStream } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import type { HttpContext } from '@adonisjs/core/http'
+
+const MIME_TYPES: Record<string, string> = {
+  '.json': 'application/json; charset=utf-8',
+  '.yaml': 'text/yaml; charset=utf-8',
+  '.yml': 'text/yaml; charset=utf-8',
+}
+
+function decodeLocation(location: string): string {
+  try {
+    return decodeURIComponent(location)
+  } catch {
+    return location
+  }
+}
+
+export function createFileServer(location: string | URL) {
+  const basePath = location instanceof URL ? fileURLToPath(location) : location
+  const resolvedBasePath = resolve(basePath)
+
+  return async function ({ request, response }: HttpContext) {
+    const requestedLocation = decodeLocation(request.param('*').join('/'))
+    const absoluteFilePath = resolve(resolvedBasePath, requestedLocation)
+    const extension = extname(absoluteFilePath)
+
+    if (!MIME_TYPES[extension]) {
+      response.status(404)
+      response.send('File not found')
+      return
+    }
+
+    if (
+      absoluteFilePath !== resolvedBasePath &&
+      !absoluteFilePath.startsWith(`${resolvedBasePath}/`)
+    ) {
+      response.status(403)
+      response.send('Access denied')
+      return
+    }
+
+    try {
+      const stats = await stat(absoluteFilePath)
+      if (!stats.isFile()) {
+        response.status(404)
+        response.send('File not found')
+        return
+      }
+
+      response.type(MIME_TYPES[extension])
+      response.header('Content-length', stats.size.toString())
+      return response.stream(createReadStream(absoluteFilePath))
+    } catch {
+      response.status(404)
+      response.send('File not found')
+      return
+    }
+  }
+}

--- a/src/file_server.ts
+++ b/src/file_server.ts
@@ -13,6 +13,8 @@ import { createReadStream } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import type { HttpContext } from '@adonisjs/core/http'
 
+import { FsLoader } from './loaders/fs.ts'
+
 const MIME_TYPES: Record<string, string> = {
   '.json': 'application/json; charset=utf-8',
   '.yaml': 'text/yaml; charset=utf-8',
@@ -27,7 +29,13 @@ function decodeLocation(location: string): string {
   }
 }
 
-export function createFileServer(location: string | URL) {
+export function createFileServer(loader: FsLoader) {
+  const location = loader.serveFiles?.location
+
+  if (!location) {
+    throw new Error('Cannot create file server without a serveFiles-enabled fs loader')
+  }
+
   const basePath = location instanceof URL ? fileURLToPath(location) : location
   const resolvedBasePath = resolve(basePath)
 

--- a/src/file_server.ts
+++ b/src/file_server.ts
@@ -13,7 +13,7 @@ import { createReadStream } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import type { HttpContext } from '@adonisjs/core/http'
 
-import { FsLoader } from './loaders/fs.ts'
+import type { FsLoader } from './loaders/fs.ts'
 
 const MIME_TYPES: Record<string, string> = {
   '.json': 'application/json; charset=utf-8',

--- a/src/loaders/fs.ts
+++ b/src/loaders/fs.ts
@@ -39,6 +39,11 @@ import type { FsLoaderOptions, Translations, TranslationsLoaderContract } from '
  * ```
  */
 export class FsLoader implements TranslationsLoaderContract {
+  serveFiles?: {
+    routePattern: string
+    location: string | URL
+  }
+
   /**
    * Base path for translation files on the filesystem
    * Resolved from URL or string path in the configuration
@@ -53,6 +58,14 @@ export class FsLoader implements TranslationsLoaderContract {
   constructor(config: FsLoaderOptions) {
     this.#storageBasePath =
       config.location instanceof URL ? fileURLToPath(config.location) : config.location
+
+    if (config.serveFiles) {
+      const routeBasePath = config.routeBasePath || 'lang'
+      this.serveFiles = {
+        location: config.location,
+        routePattern: `${routeBasePath.replace(/\/$/, '')}/*`,
+      }
+    }
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,6 +79,18 @@ export interface TranslationsLoaderContract {
  */
 export type FsLoaderOptions = {
   location: string | URL
+
+  /**
+   * Enable this option to register an HTTP route for serving
+   * translation files from the file system loader location.
+   */
+  serveFiles: true
+
+  /**
+   * Base route path used to expose translation files when
+   * "serveFiles" is enabled. Defaults to "/lang".
+   */
+  routeBasePath?: string
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,7 +84,7 @@ export type FsLoaderOptions = {
    * Enable this option to register an HTTP route for serving
    * translation files from the file system loader location.
    */
-  serveFiles: true
+  serveFiles?: true
 
   /**
    * Base route path used to expose translation files when

--- a/stubs/config/i18n.stub
+++ b/stubs/config/i18n.stub
@@ -19,7 +19,8 @@ const i18nConfig = defineConfig({
      *   - "resources/lang/it"
      */
     loaders.fs({
-      location: app.languageFilesPath()
+      location: app.languageFilesPath(),
+      serveFiles: true,
     }),
   ],
 })

--- a/tests/configure.spec.ts
+++ b/tests/configure.spec.ts
@@ -53,6 +53,7 @@ test.group('Configure', (group) => {
     await assert.fileContains('adonisrc.ts', '@adonisjs/i18n/i18n_provider')
     await assert.fileContains('adonisrc.ts', 'resources/lang/**/*.{json,yaml,yml}')
     await assert.fileContains('config/i18n.ts', 'defineConfig')
+    await assert.fileContains('config/i18n.ts', 'serveFiles: true')
     await assert.fileContains(
       'start/kernel.ts',
       `() => import('#middleware/detect_user_locale_middleware')`

--- a/tests/define_config.spec.ts
+++ b/tests/define_config.spec.ts
@@ -60,7 +60,7 @@ test.group('Define config', () => {
       formatter: formatters.icu(),
     }).resolver(app)
 
-    const loader = config.loaders[0](config)
+    const loader = config.loaders[0](config) as FsLoader
 
     assert.deepEqual(loader.serveFiles, {
       location: BASE_URL,

--- a/tests/define_config.spec.ts
+++ b/tests/define_config.spec.ts
@@ -48,4 +48,23 @@ test.group('Define config', () => {
     assert.isFunction(config.loaders[0])
     assert.instanceOf(config.loaders[0](config), FsLoader)
   })
+
+  test('attach serve files metadata to fs loader', async ({ assert }) => {
+    const config = await defineConfig({
+      loaders: [
+        loaders.fs({
+          location: BASE_URL,
+          serveFiles: true,
+        }),
+      ],
+      formatter: formatters.icu(),
+    }).resolver(app)
+
+    const loader = config.loaders[0](config)
+
+    assert.deepEqual(loader.serveFiles, {
+      location: BASE_URL,
+      routePattern: 'lang/*',
+    })
+  })
 })


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Front-end React/Vue may re-use translations strings. And the common way to load translation files is over HTTP.

So I add `serveFiles` and `routeBasePath` option to FsLoader.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
