### PR TITLE
Feat/configurable fallback

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,8 @@
  * file that was distributed with this source code.
  */
 
+import type { FieldContext } from '@vinejs/vine/types'
+
 /**
  * Options for formatting a numeric value. We override loose
  * types from "Intl.NumberFormatOptions".
@@ -146,4 +148,13 @@ export type MissingTranslationEventPayload = {
   locale: string
   identifier: string
   hasFallback: boolean
+}
+
+export type FallbackMessageOptions = {
+  defaultMessage: string
+  rule: string
+  field: FieldContext
+  meta?: Record<string, any>
+  ruleIdentifier: string
+  fieldIdentifier: string
 }

--- a/src/vine_i18n_messages_provider.ts
+++ b/src/vine_i18n_messages_provider.ts
@@ -92,9 +92,8 @@ export class I18nMessagesProvider implements MessagesProviderContact {
     /**
      * 1st priority is given to the field messages
      */
-    const fieldMessage = this.#i18n.resolveIdentifier(
-      `${this.#messagesPrefix}.${field.wildCardPath}.${rule}`
-    )
+    const fieldIdentifier = `${this.#messagesPrefix}.${field.wildCardPath}.${rule}`
+    const fieldMessage = this.#i18n.resolveIdentifier(fieldIdentifier)
     if (fieldMessage) {
       return this.#i18n.formatRawMessage(fieldMessage.message, {
         field: fieldName,
@@ -104,7 +103,8 @@ export class I18nMessagesProvider implements MessagesProviderContact {
     /**
      * 2nd priority is for rule messages
      */
-    const ruleMessage = this.#i18n.resolveIdentifier(`${this.#messagesPrefix}.${rule}`)
+    const ruleIdentifier = `${this.#messagesPrefix}.${rule}`
+    const ruleMessage = this.#i18n.resolveIdentifier(ruleIdentifier)
     if (ruleMessage) {
       return this.#i18n.formatRawMessage(ruleMessage.message, {
         field: fieldName,
@@ -113,11 +113,15 @@ export class I18nMessagesProvider implements MessagesProviderContact {
     }
 
     /**
-     * Fallback to default message
+     * 3rd priority is a fallback message
      */
-    return string.interpolate(defaultMessage, {
-      field: fieldName,
-      ...meta,
+    return this.getFallbackMessage({
+      defaultMessage,
+      rule,
+      field,
+      meta,
+      ruleIdentifier,
+      fieldIdentifier,
     })
   }
 
@@ -130,5 +134,27 @@ export class I18nMessagesProvider implements MessagesProviderContact {
       return this.#i18n.formatRawMessage(translatedFieldName.message)
     }
     return name
+  }
+
+  /**
+   * Returns a fallback for a non-translated message
+   */
+  getFallbackMessage({
+    defaultMessage,
+    field,
+    meta,
+  }: {
+    defaultMessage: string
+    rule: string
+    field: FieldContext
+    meta?: Record<string, any>
+    ruleIdentifier: string
+    fieldIdentifier: string
+  }) {
+    const fieldName = this.translateField(field.name)
+    return string.interpolate(defaultMessage, {
+      field: fieldName,
+      ...meta,
+    })
   }
 }

--- a/tests/i18n.spec.ts
+++ b/tests/i18n.spec.ts
@@ -17,8 +17,9 @@ import { I18n } from '../src/i18n.ts'
 import { FsLoader } from '../src/loaders/fs.ts'
 import { I18nManager } from '../src/i18n_manager.ts'
 import { IcuFormatter } from '../src/messages_formatters/icu.ts'
-import type { MissingTranslationEventPayload } from '../src/types.ts'
+import type { FallbackMessageOptions, MissingTranslationEventPayload } from '../src/types.ts'
 import { I18nMessagesProvider } from '../src/vine_i18n_messages_provider.ts'
+import type { FieldContext } from '@vinejs/vine/types'
 
 const app = new AppFactory().create(new URL('./', import.meta.url), () => {})
 const emitter = new Emitter<{ 'i18n:missing:translation': MissingTranslationEventPayload }>(app)
@@ -383,6 +384,48 @@ test.group('I18n | validator messages provider', () => {
         {
           field: 'number_field',
           message: 'The Number field field must be a number',
+          rule: 'number',
+        },
+      ])
+    }
+  })
+
+  test('change fallback message when extended', async ({ fs, assert }) => {
+    assert.plan(1)
+
+    await fs.createJson('resources/lang/en/validator.json', {
+      shared: { fields: { numberField: 'Number field' } },
+    })
+
+    const i18nManager = new I18nManager(emitter, {
+      defaultLocale: 'en',
+      formatter: () => new IcuFormatter(),
+      loaders: [() => new FsLoader({ location: join(fs.basePath, 'resources/lang') })],
+    })
+
+    await i18nManager.loadTranslations()
+    const i18n = new I18n('da', emitter, i18nManager)
+
+    const schema = vine.object({ number_field: vine.number() })
+
+    class FallbackProvider extends I18nMessagesProvider {
+      getFallbackMessage(options: FallbackMessageOptions) {
+        if (i18n.locale === 'en') return super.getFallbackMessage(options)
+        return i18n.t(options.ruleIdentifier, options.meta)
+      }
+    }
+
+    try {
+      await vine.validate({
+        schema,
+        data: { number_field: 'string' },
+        messagesProvider: new FallbackProvider('validator.shared', i18n),
+      })
+    } catch (error) {
+      assert.deepEqual(error.messages, [
+        {
+          field: 'number_field',
+          message: 'translation missing: da, validator.shared.messages.number',
           rule: 'number',
         },
       ])


### PR DESCRIPTION
### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Makes it possible to extend I18nMessagesProvider and override how fall back messages are generated.
For instance it will be easy to use fallback provided by i18n, so that a "translation missing" message will be displayed.

This is a draft, made for collecting feedback, and not to be merged in just yet.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
